### PR TITLE
Remove "end frame"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ where
             let item = item.into();
             self.spi.write(&[0xFF, item.b, item.g, item.r])?;
         }
-        self.spi.write(&[0xFF, 0xFF, 0xFF, 0xFF])?;
         Ok(())
     }
 }


### PR DESCRIPTION
The "end frame" causes erratic results when there're more LEDs connected
than being used by fully lighting up the following LED after the second
update of the the LED string.

Closes #1