### PR TITLE
Add PixelType to support different color orders

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,12 @@ pub struct Apa102<SPI> {
     spi: SPI,
     end_frame_length: u8,
     invert_end_frame: bool,
-    pixel_type: PixelType,
+    pixel_order: PixelOrder,
 }
 
 /// What order to transmit pixel colors. Different Dotstars
 /// need their pixel color data sent in different orders.
-pub enum PixelType {
+pub enum PixelOrder {
     RGB,
     RBG,
     GRB,
@@ -50,12 +50,14 @@ where
     /// By default, an End Frame consisting of 32 bits of zeroes is emitted
     /// following the LED data. Control over the size and polarity
     /// of the End Frame is possible using new_with_custom_postamble().
+    /// PixelOrder defaults to BGR ordering, and can also be customized
+    /// using new_with_custom_postamble
     pub fn new(spi: SPI) -> Apa102<SPI> {
         Self {
             spi,
             end_frame_length: 4,
             invert_end_frame: true,
-            pixel_type: PixelType::BGR,
+            pixel_order: PixelOrder::BGR,
         }
     }
 
@@ -63,13 +65,13 @@ where
         spi: SPI,
         end_frame_length: u8,
         invert_end_frame: bool,
-        pixel_type: PixelType,
+        pixel_order: PixelOrder,
     ) -> Apa102<SPI> {
         Self {
             spi,
             end_frame_length,
             invert_end_frame,
-            pixel_type,
+            pixel_order,
         }
     }
 }
@@ -89,13 +91,13 @@ where
         self.spi.write(&[0x00, 0x00, 0x00, 0x00])?;
         for item in iterator {
             let item = item.into();
-            match self.pixel_type {
-                PixelType::RGB => self.spi.write(&[0xFF, item.r, item.g, item.b])?,
-                PixelType::RBG => self.spi.write(&[0xFF, item.r, item.b, item.g])?,
-                PixelType::GRB => self.spi.write(&[0xFF, item.g, item.r, item.b])?,
-                PixelType::GBR => self.spi.write(&[0xFF, item.g, item.b, item.r])?,
-                PixelType::BRG => self.spi.write(&[0xFF, item.b, item.r, item.g])?,
-                PixelType::BGR => self.spi.write(&[0xFF, item.b, item.g, item.r])?,
+            match self.pixel_order {
+                PixelOrder::RGB => self.spi.write(&[0xFF, item.r, item.g, item.b])?,
+                PixelOrder::RBG => self.spi.write(&[0xFF, item.r, item.b, item.g])?,
+                PixelOrder::GRB => self.spi.write(&[0xFF, item.g, item.r, item.b])?,
+                PixelOrder::GBR => self.spi.write(&[0xFF, item.g, item.b, item.r])?,
+                PixelOrder::BRG => self.spi.write(&[0xFF, item.b, item.r, item.g])?,
+                PixelOrder::BGR => self.spi.write(&[0xFF, item.b, item.g, item.r])?,
             }
         }
         for _ in 0..self.end_frame_length {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@ where
     /// new constructs a controller for a series of APA102 LEDs.
     /// By default, an End Frame consisting of 32 bits of zeroes is emitted
     /// following the LED data. Control over the size and polarity
-    /// of the End Frame is possible using new_with_custom_postamble().
+    /// of the End Frame is possible using new_with_options().
     /// PixelOrder defaults to BGR ordering, and can also be customized
-    /// using new_with_custom_postamble
+    /// using new_with_options()
     pub fn new(spi: SPI) -> Apa102<SPI> {
         Self {
             spi,
@@ -61,7 +61,7 @@ where
         }
     }
 
-    pub fn new_with_custom_postamble(
+    pub fn new_with_options(
         spi: SPI,
         end_frame_length: u8,
         invert_end_frame: bool,


### PR DESCRIPTION
The DotStars I'm using on one of my boards use RBG order, instead of BGR order. I added a `PixelType` enum, and then write out to SPI in different orders depending on the `PixelType`.

I added all the different permutations that are present in the [Adafruit dotstar library](https://github.com/adafruit/Adafruit_DotStar/blob/master/Adafruit_DotStar.h#L33). Not sure how many of these permutations are actually found in the wild.

Would you also take a patch for implementing the `Default` trait on `Apa102`? Might be a little cleaner.

Thank you so much for the library! It's working great on my board so far. :-)

Tested locally on my board.