### PR TITLE
Allow the consumed Spi instance to be freed consuming the driver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,11 @@ where
             pixel_order,
         }
     }
+
+    /// Free the owned resources consuming self
+    pub fn free(self) -> SPI {
+        self.spi
+    }
 }
 
 impl<SPI, E> SmartLedsWrite for Apa102<SPI>


### PR DESCRIPTION
Necessary for https://github.com/SCingolani/rp-hal-boards/tree/pololu-threepi-plus-2040 where the Spi interface needs to be reconfigured and shared between two devices.

This change consumes the `Apa102` and returns to the user the `Spi`.