### PR TITLE
add Apa102Pixel struct and FastLED's pseudo-13-bit gamma correction algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ defmt = { version = "0.3.0", optional = true }
 
 [features]
 defmt = [ "dep:defmt" ]
+
+[dev-dependencies]
+fastrand = "2.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ defmt = [ "dep:defmt" ]
 
 [dev-dependencies]
 fastrand = "2.3.0"
+
+[package.metadata.docs.rs]
+all-features = true
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/smart-leds-rs/apa102-spi-rs"
 smart-leds-trait = "0.3.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
+ux = "0.1"
 defmt = { version = "0.3.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,7 @@ repository = "https://github.com/smart-leds-rs/apa102-spi-rs"
 smart-leds-trait = "0.3.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
+defmt = { version = "0.3.0", optional = true }
 
+[features]
+defmt = [ "dep:defmt" ]

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -74,7 +74,7 @@ where
                 PixelOrder::RGB => {
                     self.spi
                         .write(&[
-                            0b11100000 | item.brightness,
+                            0b11100000 | u8::from(item.brightness),
                             item.red,
                             item.green,
                             item.blue,
@@ -84,7 +84,7 @@ where
                 PixelOrder::RBG => {
                     self.spi
                         .write(&[
-                            0b11100000 | item.brightness,
+                            0b11100000 | u8::from(item.brightness),
                             item.red,
                             item.blue,
                             item.green,
@@ -94,7 +94,7 @@ where
                 PixelOrder::GRB => {
                     self.spi
                         .write(&[
-                            0b11100000 | item.brightness,
+                            0b11100000 | u8::from(item.brightness),
                             item.green,
                             item.red,
                             item.blue,
@@ -104,7 +104,7 @@ where
                 PixelOrder::GBR => {
                     self.spi
                         .write(&[
-                            0b11100000 | item.brightness,
+                            0b11100000 | u8::from(item.brightness),
                             item.green,
                             item.blue,
                             item.red,
@@ -114,7 +114,7 @@ where
                 PixelOrder::BRG => {
                     self.spi
                         .write(&[
-                            0b11100000 | item.brightness,
+                            0b11100000 | u8::from(item.brightness),
                             item.blue,
                             item.red,
                             item.green,
@@ -124,7 +124,7 @@ where
                 PixelOrder::BGR => {
                     self.spi
                         .write(&[
-                            0b11100000 | item.brightness,
+                            0b11100000 | u8::from(item.brightness),
                             item.blue,
                             item.green,
                             item.red,

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -1,14 +1,9 @@
-//! Use APA102 leds via SPI with asynchronous writing of data via the
-//! [`embedded_hal_async::spi::SpiBus`](https://docs.rs/embedded-hal-async/latest/embedded_hal_async/spi/trait.SpiBus.html) trait.
-//!
-//! - For usage with `smart-leds`
-//! - Implements the `SmartLedsWriteAsync` trait
-
 use crate::{Apa102Pixel, PixelOrder};
 
 use embedded_hal_async::spi::SpiBus;
 use smart_leds_trait::SmartLedsWriteAsync;
 
+/// A writer for APA102 LEDs
 pub struct Apa102Async<SPI> {
     spi: SPI,
     end_frame_length: u8,

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -3,15 +3,11 @@
 //!
 //! - For usage with `smart-leds`
 //! - Implements the `SmartLedsWriteAsync` trait
-//!
-//! Doesn't use the native brightness settings of the apa102 leds, since that
-//! runs at a much lower pwm frequency and thus nerfes the very high color pwm
-//! frequency. (According to Adafruit)
 
-use crate::PixelOrder;
+use crate::{Apa102Pixel, PixelOrder};
 
 use embedded_hal_async::spi::SpiBus;
-use smart_leds_trait::{RGB8, SmartLedsWriteAsync};
+use smart_leds_trait::SmartLedsWriteAsync;
 
 pub struct Apa102Async<SPI> {
     spi: SPI,
@@ -63,7 +59,7 @@ impl<SPI> SmartLedsWriteAsync for Apa102Async<SPI>
 where
     SPI: SpiBus,
 {
-    type Color = RGB8;
+    type Color = Apa102Pixel;
     type Error = SPI::Error;
     /// Write all the items of an iterator to an apa102 strip
     async fn write<T, I>(&mut self, iterator: T) -> Result<(), SPI::Error>
@@ -75,12 +71,66 @@ where
         for item in iterator {
             let item = item.into();
             match self.pixel_order {
-                PixelOrder::RGB => self.spi.write(&[0xFF, item.r, item.g, item.b]).await?,
-                PixelOrder::RBG => self.spi.write(&[0xFF, item.r, item.b, item.g]).await?,
-                PixelOrder::GRB => self.spi.write(&[0xFF, item.g, item.r, item.b]).await?,
-                PixelOrder::GBR => self.spi.write(&[0xFF, item.g, item.b, item.r]).await?,
-                PixelOrder::BRG => self.spi.write(&[0xFF, item.b, item.r, item.g]).await?,
-                PixelOrder::BGR => self.spi.write(&[0xFF, item.b, item.g, item.r]).await?,
+                PixelOrder::RGB => {
+                    self.spi
+                        .write(&[
+                            0b11100000 | item.brightness,
+                            item.red,
+                            item.green,
+                            item.blue,
+                        ])
+                        .await?
+                }
+                PixelOrder::RBG => {
+                    self.spi
+                        .write(&[
+                            0b11100000 | item.brightness,
+                            item.red,
+                            item.blue,
+                            item.green,
+                        ])
+                        .await?
+                }
+                PixelOrder::GRB => {
+                    self.spi
+                        .write(&[
+                            0b11100000 | item.brightness,
+                            item.green,
+                            item.red,
+                            item.blue,
+                        ])
+                        .await?
+                }
+                PixelOrder::GBR => {
+                    self.spi
+                        .write(&[
+                            0b11100000 | item.brightness,
+                            item.green,
+                            item.blue,
+                            item.red,
+                        ])
+                        .await?
+                }
+                PixelOrder::BRG => {
+                    self.spi
+                        .write(&[
+                            0b11100000 | item.brightness,
+                            item.blue,
+                            item.red,
+                            item.green,
+                        ])
+                        .await?
+                }
+                PixelOrder::BGR => {
+                    self.spi
+                        .write(&[
+                            0b11100000 | item.brightness,
+                            item.blue,
+                            item.green,
+                            item.red,
+                        ])
+                        .await?
+                }
             }
         }
         for _ in 0..self.end_frame_length {

--- a/src/bitshift.rs
+++ b/src/bitshift.rs
@@ -1,0 +1,265 @@
+// Manually translated to Rust from FastLED's MIT licensed C++ code
+
+/// Steal brightness from brightness_src and give it to brightness_dst.
+/// After this function concludes the multiplication of brightness_dst and brightness_src will remain constant.
+pub(crate) fn brightness_bitshifter8(
+    brightness_src: &mut u8,
+    brightness_dst: &mut u8,
+    max_shifts: u8,
+) -> u8 {
+    if *brightness_dst == 0 || *brightness_src == 0 {
+        return 0;
+    }
+    let mut shifts = 0;
+    while shifts < max_shifts && *brightness_src > 1 {
+        if *brightness_dst & 0b10000000 > 0 {
+            // next shift will overflow
+            break;
+        }
+        *brightness_src >>= 1;
+        *brightness_dst <<= 1;
+        shifts += 1;
+    }
+    shifts
+}
+
+/// Return value is the number of shifts on the src. Multiply this by the number of steps to get the
+/// the number of shifts on the dst.
+pub(crate) fn brightness_bitshifter16(
+    brightness_src: &mut u8,
+    brightness_dst: &mut u16,
+    max_shifts: u8,
+    steps: u8,
+) -> u8 {
+    if *brightness_dst == 0 || *brightness_src == 0 {
+        return 0;
+    }
+    let mut overflow_mask = 0b1000000000000000;
+    let mut i = 1;
+    while i < steps {
+        overflow_mask >>= 1;
+        overflow_mask |= 0b1000000000000000;
+        i += 1;
+    }
+    let underflow_mask = 0x1;
+
+    // Steal brightness from brightness_src and give it to brightness_dst.
+    // After this function concludes the multiplication of brightness_dst and brightness_src will remain
+    // constant.
+    let mut shifts = 0;
+    while shifts < max_shifts {
+        if *brightness_src & underflow_mask > 0 {
+            break;
+        }
+        if *brightness_dst & overflow_mask > 0 {
+            // next shift will overflow
+            break;
+        }
+        *brightness_src >>= 1;
+        *brightness_dst <<= steps;
+        shifts += 1;
+    }
+    shifts
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_brightness_bitshifter8_random() {
+        let mut count = 0;
+        for _ in 0..10000 {
+            let mut brightness_src = 0b10000000 >> fastrand::u8(..) % 6;
+            let mut brightness_dst = fastrand::u8(..);
+            let product = brightness_src as u16 * brightness_dst as u16;
+            let shifts = brightness_bitshifter8(&mut brightness_src, &mut brightness_dst, 7);
+            let new_product = brightness_src as u16 * brightness_dst as u16;
+            assert_eq!(product, new_product);
+            if shifts > 0 {
+                count += 1;
+            }
+        }
+        assert!(count > 0);
+    }
+
+    #[test]
+    fn test_brightness_bitshifter8_fixed_data() {
+        #[rustfmt::skip]
+        let test_data = [
+            // brightness_bitshifter8 is always called with brightness_src = 0b00010000
+            [ // test case
+                // src       dst
+                [0b00010000, 0b00000000], // input
+                [0b00010000, 0b00000000], // output
+            ],
+            [
+                [0b00010000, 0b00000001],
+                [0b00000001, 0b00010000]
+            ],
+            [
+                [0b00010000, 0b00000100],
+                [0b00000001, 0b01000000]
+            ],
+            [
+                [0b00010000, 0b00010000],
+                [0b00000010, 0b10000000]
+            ],
+            [
+                [0b00010000, 0b00001010],
+                [0b00000001, 0b10100000]
+            ],
+            [
+                [0b00010000, 0b00101010],
+                [0b00000100, 0b10101000]
+            ],
+            [
+                [0b00010000, 0b11101010],
+                [0b00010000, 0b11101010]
+            ],
+        ];
+
+        for data in test_data {
+            let mut brightness_src = data[0][0];
+            let mut brightness_dst = data[0][1];
+            let shifts = brightness_bitshifter8(&mut brightness_src, &mut brightness_dst, 4);
+            assert_eq!(
+                brightness_src, data[1][0],
+                "
+input  brightness_src: {} ; input  brightness_dst: {}
+output brightness_src: {brightness_src} ; output brightness_dst: {brightness_dst}
+shifts: {shifts}",
+                data[0][0], data[0][1]
+            );
+            assert_eq!(
+                brightness_dst, data[1][1],
+                "
+input  brightness_src: {} ; input  brightness_dst: {}
+output brightness_src: {brightness_src} ; output brightness_dst: {brightness_dst}
+shifts: {shifts}",
+                data[0][0], data[0][1]
+            );
+        }
+    }
+
+    #[test]
+    fn test_brightness_bitshifter16_steps2() {
+        let mut brightness_src = 0x1 << 1;
+        let mut brightness_dst = 0x1 << 2;
+        let max_shifts = 8;
+
+        let shifts =
+            brightness_bitshifter16(&mut brightness_src, &mut brightness_dst, max_shifts, 2);
+
+        assert_eq!(shifts, 1);
+        assert_eq!(brightness_src, 1);
+        assert_eq!(brightness_dst, 0x1 << 4);
+    }
+
+    #[test]
+    fn test_brightness_bitshifter16_steps1() {
+        let mut brightness_src = 0x1 << 1;
+        let mut brightness_dst = 0x1 << 1;
+        let max_shifts = 8;
+
+        let shifts =
+            brightness_bitshifter16(&mut brightness_src, &mut brightness_dst, max_shifts, 1);
+
+        assert_eq!(shifts, 1);
+        assert_eq!(brightness_src, 1);
+        assert_eq!(brightness_dst, 0x1 << 2);
+    }
+
+    #[test]
+    fn test_brightness_bitshifter16_random() {
+        let mut count = 0;
+        for _ in 0..10000 {
+            let mut brightness_src = 0b10000000 >> (fastrand::u8(..) % 8);
+            let mut brightness_dst = fastrand::u16(..);
+            let product = (brightness_src as u32 >> 8) * brightness_dst as u32;
+            let max_shifts = 8;
+            let steps = 2;
+
+            let shifts = brightness_bitshifter16(
+                &mut brightness_src,
+                &mut brightness_dst,
+                max_shifts,
+                steps,
+            );
+
+            let new_product = (brightness_src as u32 >> 8) * brightness_dst as u32;
+            assert_eq!(product, new_product);
+            if shifts > 0 {
+                count += 1;
+            }
+        }
+        assert!(count > 0);
+    }
+
+    #[test]
+    fn test_brightness_bitshifter16_fixed_data() {
+        let test_data = [
+            // brightness_bitshifter16 is always called with brightness_src between 0b00000001 - 0b00010000
+            [
+                // test case
+                // src       dst
+                [0b00000001, 0b0000000000000000], // input
+                [0b00000001, 0b0000000000000000], // output
+            ],
+            [
+                [0b00000001, 0b0000000000000001],
+                [0b00000001, 0b0000000000000001],
+            ],
+            [
+                [0b00000001, 0b0000000000000010],
+                [0b00000001, 0b0000000000000010],
+            ],
+            [
+                [0b00000010, 0b0000000000000001],
+                [0b00000001, 0b0000000000000100],
+            ],
+            [
+                [0b00001010, 0b0000000000001010],
+                [0b00000101, 0b0000000000101000],
+            ],
+            [
+                [0b00010000, 0b0000111000100100],
+                [0b00000100, 0b1110001001000000],
+            ],
+            [
+                [0b00010000, 0b0011100010010010],
+                [0b00001000, 0b1110001001001000],
+            ],
+            [
+                [0b00010000, 0b0110001001001110],
+                [0b00010000, 0b0110001001001110],
+            ],
+            [
+                [0b00010000, 0b1110001001001110],
+                [0b00010000, 0b1110001001001110],
+            ],
+        ];
+
+        for data in test_data {
+            let mut brightness_src = data[0][0] as u8;
+            let mut brightness_dst = data[0][1];
+            let shifts = brightness_bitshifter16(&mut brightness_src, &mut brightness_dst, 4, 2);
+            assert_eq!(
+                brightness_src, data[1][0] as u8,
+                "
+input  brightness_src: {} ; input  brightness_dst: {}
+output brightness_src: {brightness_src} ; output brightness_dst: {brightness_dst}
+shifts (by 2 bits) : {shifts}",
+                data[0][0], data[0][1]
+            );
+            assert_eq!(
+                brightness_dst, data[1][1],
+                "
+input  brightness_src: {} ; input  brightness_dst: {}
+output brightness_src: {brightness_src} ; output brightness_dst: {brightness_dst}
+shifts (by 2 bits) : {shifts}",
+                data[0][0], data[0][1]
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@
 //! led_strip.write(led_buffer_rgb.map(
 //!   |p| Apa102Pixel::from_rgb8_with_brightness(p, 255, None)));
 //! ```
+//!
+//! ## Cargo features
+//!   * `defmt`: impl [defmt::Format] for [Apa102Pixel] (off by default)
 
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use asynch::Apa102Async;
 
 mod pixel;
 pub use pixel::Apa102Pixel;
+pub use ux::u5;
 
 mod bitshift;
 mod math;
@@ -104,37 +105,37 @@ where
             let item = item.into();
             match self.pixel_order {
                 PixelOrder::RGB => self.spi.write(&[
-                    0b11100000 | item.brightness,
+                    0b11100000 | u8::from(item.brightness),
                     item.red,
                     item.green,
                     item.blue,
                 ])?,
                 PixelOrder::RBG => self.spi.write(&[
-                    0b11100000 | item.brightness,
+                    0b11100000 | u8::from(item.brightness),
                     item.red,
                     item.blue,
                     item.green,
                 ])?,
                 PixelOrder::GRB => self.spi.write(&[
-                    0b11100000 | item.brightness,
+                    0b11100000 | u8::from(item.brightness),
                     item.green,
                     item.red,
                     item.blue,
                 ])?,
                 PixelOrder::GBR => self.spi.write(&[
-                    0b11100000 | item.brightness,
+                    0b11100000 | u8::from(item.brightness),
                     item.green,
                     item.blue,
                     item.red,
                 ])?,
                 PixelOrder::BRG => self.spi.write(&[
-                    0b11100000 | item.brightness,
+                    0b11100000 | u8::from(item.brightness),
                     item.blue,
                     item.red,
                     item.green,
                 ])?,
                 PixelOrder::BGR => self.spi.write(&[
-                    0b11100000 | item.brightness,
+                    0b11100000 | u8::from(item.brightness),
                     item.blue,
                     item.green,
                     item.red,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@ pub use asynch::Apa102Async;
 mod pixel;
 pub use pixel::Apa102Pixel;
 
+mod bitshift;
+mod math;
+mod pseudo13;
+
 use embedded_hal::spi::SpiBus;
 use embedded_hal::spi::{Mode, Phase, Polarity};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,61 @@
-//! # Use apa102 leds via spi
+//! Send data to APA102 LEDs via SPI. This crate provides both blocking and asynchronous implementations, which require a HAL crate for your microcontroller with an implementation of the [embedded_hal::spi::SpiBus] or [embedded_hal_async::spi::SpiBus] trait.
 //!
-//! - For usage with `smart-leds`
-//! - Implements the `SmartLedsWrite` trait
+//! There are several ways to send pixel data:
+//!   * Handle all details of the protocol yourself with the [Apa102Pixel] struct, 8 bit RGB + 5 bits brightness
+//!   * Simply provide [smart_leds_trait::RGB8] values, hardcoding maximum brightness. This may be uncomfortably bright.
+//!   * Use [FastLED's pseudo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/master/APA102.md) to convert [smart_leds_trait::RGB8] + 8 bit brightness to 8 bit RGB + 5 bit brightness.
 //!
-//! Needs a type implementing the `blocking::spi::Write` trait.
+//! ```
+//! # use embedded_hal::spi::{SpiBus, ErrorType, ErrorKind};
+//! # struct DummySpi;
+//! # impl ErrorType for DummySpi {
+//! #   type Error = ErrorKind;
+//! # }
+//! #
+//! # impl SpiBus for DummySpi {
+//! #   fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+//! #     Ok(())
+//! #   }
+//! #
+//! #   fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+//! #     Ok(())
+//! #   }
+//! #
+//! #   fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+//! #     Ok(())
+//! #   }
+//! #
+//! #   fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+//! #     Ok(())
+//! #   }
+//! #
+//! #   fn flush(&mut self) -> Result<(), Self::Error> {
+//! #     Ok(())
+//! #   }
+//! # }
+//! # let get_spi_peripheral_from_your_hal = DummySpi {};
+//! use smart_leds_trait::{SmartLedsWrite, RGB8};
+//! use apa102_spi::{Apa102, Apa102Pixel, u5};
+//!
+//! // You only need to specify MOSI and clock pins for your SPI peripheral.
+//! // APA102 LEDs do not send data over MISO and do not have a CS pin.
+//! let spi = get_spi_peripheral_from_your_hal;
+//! let mut led_strip = Apa102::new(spi);
+//!
+//! // Specify pixel values as 8 bit RGB + 5 bit brightness
+//! let led_buffer = [Apa102Pixel { red: 255, green: 0, blue: 0, brightness: u5::new(1) }];
+//! led_strip.write(led_buffer);
+//!
+//! // Specify pixel values with 8 bit RGB values
+//! let led_buffer_rgb = [RGB8 { r: 255, g: 0, b: 0}];
+//! // Brightness is set to maximum value (31) in `impl From<RGB8> for Apa102Pixel`
+//! led_strip.write(led_buffer_rgb);
+//!
+//! // Convert RGB8 + 8 bit brightness into Apa102Pixels
+//! // using FastLED's pseudo-13-bit gamma correction algorithm.
+//! led_strip.write(led_buffer_rgb.map(
+//!   |p| Apa102Pixel::from_rgb8_with_brightness(p, 255, None)));
+//! ```
 
 #![no_std]
 
@@ -31,6 +83,7 @@ pub const MODE: Mode = Mode {
     phase: Phase::CaptureOnFirstTransition,
 };
 
+/// A writer for APA102 LEDs
 pub struct Apa102<SPI> {
     spi: SPI,
     end_frame_length: u8,

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,65 @@
+// Manually translated to Rust from FastLED's MIT licensed C++ code
+
+/// Scale a 16-bit unsigned value by an 8-bit value, which is treated
+/// as the numerator of a fraction whose denominator is `u8::MAX`.
+///
+/// In other words, it computes `i * (scale / u8::MAX)`
+pub(crate) fn scale16by8(i: u16, scale: u8) -> u16 {
+    if scale == 0 {
+        return 0;
+    }
+    ((i as u32 * (1 + scale as u32)) >> 8) as u16
+}
+
+/// Maps an integer from one integer size to another.
+///
+/// For example, a value representing 40% as a `u16` would be `26,214 / 65,535`.
+/// Converting that to a `u8` would return `102 / 255`, exactly 40% through the
+/// range of values representable by a `u8`.
+pub(crate) fn map16_to_8(x: u16) -> u8 {
+    // Tested to be nearly identical to double precision floating point
+    // doing this operation.
+    if x >= 0xff00 {
+        return 0xff;
+    }
+    ((x + 128) >> 8) as u8
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    // This test was translated from FastLED's test
+    fn scale16by8_test() {
+        assert_eq!(scale16by8(0, 0), 0);
+        assert_eq!(scale16by8(0, 1), 0);
+        assert_eq!(scale16by8(1, 0), 0);
+        assert_eq!(scale16by8(0xffff, 0xff), 0xffff);
+        assert_eq!(scale16by8(0xffff, 0xff >> 1), 0xffff >> 1);
+        assert_eq!(scale16by8(0xffff >> 1, 0xff >> 1), 0xffff >> 2);
+
+        let mut i = 0;
+        while i < 16 {
+            let mut j = 0;
+            while j < 8 {
+                let total_bitshift = i + j;
+                if total_bitshift > 7 {
+                    break;
+                }
+                assert_eq!(scale16by8(0xffff >> i, 0xff >> j), 0xffff >> total_bitshift);
+                j += 1;
+            }
+            i += 1;
+        }
+    }
+
+    #[test]
+    fn map16_to_8_test() {
+        assert_eq!(map16_to_8(u16::MAX), u8::MAX);
+        assert_eq!(map16_to_8(49151), 192); // 75% of range
+        assert_eq!(map16_to_8(26214), 102); // 40% of range
+        assert_eq!(map16_to_8(16383), 64); // 25% of range
+        assert_eq!(map16_to_8(0), 0);
+    }
+}

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,0 +1,26 @@
+use smart_leds_trait::RGB8;
+
+/// This struct represents a single APA102 pixel, which uses 8 bits each for red, green, and blue, plus 5 bits for brightness.
+/// Brightness is represented by a `u8` without any checks for valid values to make this struct a
+/// zero-cost abstraction. Any `u8` values above the maximum for 5 bits (0b00011111 in binary or 31 in decimal)
+/// will be truncated to the maximum when writing data to the APA102 LEDs.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Apa102Pixel {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+    pub brightness: u8,
+}
+
+impl From<RGB8> for Apa102Pixel {
+    /// RGB values are copied as-is and brightness is set to the maximum value (31).
+    fn from(old: RGB8) -> Self {
+        Self {
+            red: old.r,
+            green: old.g,
+            blue: old.b,
+            brightness: 0b00011111,
+        }
+    }
+}

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,4 +1,4 @@
-use smart_leds_trait::RGB8;
+use smart_leds_trait::{RGB16, RGB8};
 
 /// This struct represents a single APA102 pixel, which uses 8 bits each for red, green, and blue, plus 5 bits for brightness.
 /// Brightness is represented by a `u8` without any checks for valid values to make this struct a
@@ -22,5 +22,36 @@ impl From<RGB8> for Apa102Pixel {
             blue: old.b,
             brightness: 0b00011111,
         }
+    }
+}
+
+impl Apa102Pixel {
+    /// Convert an [rgb::RGB8](https://docs.rs/rgb/latest/rgb/type.RGB8.html) to an [Apa102Pixel]
+    /// with a specified brightness level. Any [u8] is a valid brightness level from 0 to 255.
+    /// [FastLED's psuedo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/d5aaf65be19782f3e52b8b0fe38778f14376a293/APA102.md)
+    /// is used to make use of the dynamic range available from the APA102 protocol, preserving
+    /// color detail at low brightness. In short, it converts:
+    ///
+    /// RGB8 + 8-bit brightness → RGB16 + 5-bit gamma → RGB8 + 5-bit gamma
+    ///
+    /// Optional color correction can be applied between the gamma correction and bitshifting steps.
+    pub fn from_rgb8_with_brightness(
+        rgb8: RGB8,
+        brightness: u8,
+        color_correction: Option<&RGB8>,
+    ) -> Self {
+        crate::pseudo13::five_bit_hd_gamma_bitshift(&rgb8, brightness, color_correction)
+    }
+
+    /// Convert an [rgb::RGB16](https://docs.rs/rgb/latest/rgb/type.RGB16.html) to an [Apa102Pixel]
+    /// with a specified brightness level. Any [u8] is a valid brightness level from 0 to 255.
+    /// [FastLED's psuedo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/d5aaf65be19782f3e52b8b0fe38778f14376a293/APA102.md)
+    /// is used to make use of the dynamic range available from the APA102 protocol, preserving
+    /// color detail at low brightness.
+    ///
+    /// This function does not apply gamma correction; the [rgb::RGB16](https://docs.rs/rgb/latest/rgb/type.RGB16.html)
+    /// input is assumed to be gamma corrected already.
+    pub fn from_rgb16_with_brightness(rgb16: RGB16, brightness: u8) -> Self {
+        crate::pseudo13::five_bit_bitshift(rgb16, brightness)
     }
 }

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,16 +1,27 @@
 use smart_leds_trait::{RGB16, RGB8};
+use ux::u5;
 
-/// This struct represents a single APA102 pixel, which uses 8 bits each for red, green, and blue, plus 5 bits for brightness.
-/// Brightness is represented by a `u8` without any checks for valid values to make this struct a
-/// zero-cost abstraction. Any `u8` values above the maximum for 5 bits (0b00011111 in binary or 31 in decimal)
-/// will be truncated to the maximum when writing data to the APA102 LEDs.
+/// A single APA102 pixel: 8 bits each for red, green, and blue, plus 5 bits for brightness
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Apa102Pixel {
     pub red: u8,
     pub green: u8,
     pub blue: u8,
-    pub brightness: u8,
+    pub brightness: u5,
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Apa102Pixel {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(
+            fmt,
+            "Apa102Pixel {{ red: {=u8:?}, green: {=u8:?}, blue: {=u8:?}, brightness: {=u8:?} }}",
+            self.red,
+            self.green,
+            self.blue,
+            u8::from(self.brightness)
+        );
+    }
 }
 
 impl From<RGB8> for Apa102Pixel {
@@ -20,7 +31,7 @@ impl From<RGB8> for Apa102Pixel {
             red: old.r,
             green: old.g,
             blue: old.b,
-            brightness: 0b00011111,
+            brightness: u5::MAX,
         }
     }
 }

--- a/src/pseudo13.rs
+++ b/src/pseudo13.rs
@@ -1,0 +1,217 @@
+// Manually translated to Rust from FastLED's MIT licensed C++ code
+// https://github.com/FastLED/FastLED/blob/1c12d96931d8974fba9d64a443a2e7f5850002b2/src/five_bit_hd_gamma.cpp
+
+use crate::{bitshift::*, math::*, Apa102Pixel};
+use core::cmp::max;
+use smart_leds_trait::{RGB16, RGB8};
+
+pub(crate) fn five_bit_bitshift(mut in_color: RGB16, mut brightness: u8) -> Apa102Pixel {
+    if brightness == 0 {
+        return Apa102Pixel {
+            red: 0,
+            green: 0,
+            blue: 0,
+            brightness: 0,
+        };
+    }
+
+    if in_color.r == 0 && in_color.g == 0 && in_color.b == 0 {
+        return Apa102Pixel {
+            red: 0,
+            green: 0,
+            blue: 0,
+            brightness: if brightness <= 0b00011111 {
+                brightness
+            } else {
+                0b00011111
+            },
+        };
+    }
+
+    // Note: One day someone smarter than me will come along and invent a closed
+    // form solution for this. However, the numerical method works extremely
+    // well and has been optimized to avoid division performance penalties as
+    // much as possible.
+
+    // Step 1: Initialize brightness
+    let mut v5 = 0b00010000;
+    // Step 2: Boost brightness by swapping power with the driver brightness.
+    brightness_bitshifter8(&mut v5, &mut brightness, 4);
+
+    // Step 3: Boost brightness of the color channels by swapping power with the
+    // driver brightness.
+    let mut max_component = max(max(in_color.r, in_color.g), in_color.b);
+    let shifts = brightness_bitshifter16(&mut v5, &mut max_component, 4, 2);
+    if shifts > 0 {
+        in_color.r <<= shifts;
+        in_color.g <<= shifts;
+        in_color.b <<= shifts;
+    }
+
+    // Step 4: scale by final brightness factor.
+    if brightness != u8::MAX {
+        in_color.r = scale16by8(in_color.r, brightness);
+        in_color.g = scale16by8(in_color.g, brightness);
+        in_color.b = scale16by8(in_color.b, brightness);
+    }
+
+    // brighten hardware brightness by turning on low order bits
+    if v5 > 1 {
+        // since v5 is a power of two, subtracting one will invert the leading bit
+        // and invert all the bits below it.
+        // Example: 0b00010000 -1 = 0b00001111
+        // So 0b00010000 | 0b00001111 = 0b00011111
+        v5 = v5 | (v5 - 1);
+    }
+    // Step 5: Convert back to 8-bit and output.
+    Apa102Pixel {
+        red: map16_to_8(in_color.r),
+        green: map16_to_8(in_color.g),
+        blue: map16_to_8(in_color.b),
+        brightness: v5,
+    }
+}
+
+/// Look up table for gamma16 correction at power of 2.8
+#[rustfmt::skip]
+static GAMMA_TABLE: [u16; 256] = [
+    0,     0,     0,     1,     1,     2,     4,     6,     8,     11,    14,
+    18,    23,    29,    35,    41,    49,    57,    67,    77,    88,    99,
+    112,   126,   141,   156,   173,   191,   210,   230,   251,   274,   297,
+    322,   348,   375,   404,   433,   464,   497,   531,   566,   602,   640,
+    680,   721,   763,   807,   853,   899,   948,   998,   1050,  1103,  1158,
+    1215,  1273,  1333,  1394,  1458,  1523,  1590,  1658,  1729,  1801,  1875,
+    1951,  2029,  2109,  2190,  2274,  2359,  2446,  2536,  2627,  2720,  2816,
+    2913,  3012,  3114,  3217,  3323,  3431,  3541,  3653,  3767,  3883,  4001,
+    4122,  4245,  4370,  4498,  4627,  4759,  4893,  5030,  5169,  5310,  5453,
+    5599,  5747,  5898,  6051,  6206,  6364,  6525,  6688,  6853,  7021,  7191,
+    7364,  7539,  7717,  7897,  8080,  8266,  8454,  8645,  8838,  9034,  9233,
+    9434,  9638,  9845,  10055, 10267, 10482, 10699, 10920, 11143, 11369, 11598,
+    11829, 12064, 12301, 12541, 12784, 13030, 13279, 13530, 13785, 14042, 14303,
+    14566, 14832, 15102, 15374, 15649, 15928, 16209, 16493, 16781, 17071, 17365,
+    17661, 17961, 18264, 18570, 18879, 19191, 19507, 19825, 20147, 20472, 20800,
+    21131, 21466, 21804, 22145, 22489, 22837, 23188, 23542, 23899, 24260, 24625,
+    24992, 25363, 25737, 26115, 26496, 26880, 27268, 27659, 28054, 28452, 28854,
+    29259, 29667, 30079, 30495, 30914, 31337, 31763, 32192, 32626, 33062, 33503,
+    33947, 34394, 34846, 35300, 35759, 36221, 36687, 37156, 37629, 38106, 38586,
+    39071, 39558, 40050, 40545, 41045, 41547, 42054, 42565, 43079, 43597, 44119,
+    44644, 45174, 45707, 46245, 46786, 47331, 47880, 48432, 48989, 49550, 50114,
+    50683, 51255, 51832, 52412, 52996, 53585, 54177, 54773, 55374, 55978, 56587,
+    57199, 57816, 58436, 59061, 59690, 60323, 60960, 61601, 62246, 62896, 63549,
+    64207, 64869, 65535];
+
+pub(crate) fn five_bit_hd_gamma_bitshift(
+    colors: &RGB8,
+    brightness: u8,
+    color_correction: Option<&RGB8>,
+) -> Apa102Pixel {
+    if brightness == 0 {
+        return Apa102Pixel {
+            red: 0,
+            blue: 0,
+            green: 0,
+            brightness: 0,
+        };
+    }
+
+    let mut rgb16 = RGB16 {
+        r: GAMMA_TABLE[colors.r as usize],
+        g: GAMMA_TABLE[colors.g as usize],
+        b: GAMMA_TABLE[colors.b as usize],
+    };
+
+    if let Some(color_correction) = color_correction {
+        if color_correction.r != u8::MAX {
+            rgb16.r = scale16by8(rgb16.r, color_correction.r);
+        }
+        if color_correction.g != u8::MAX {
+            rgb16.g = scale16by8(rgb16.g, color_correction.g);
+        }
+        if color_correction.b != u8::MAX {
+            rgb16.b = scale16by8(rgb16.b, color_correction.b);
+        }
+    }
+
+    five_bit_bitshift(rgb16, brightness)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_five_bit_bitshift() {
+        #[rustfmt::skip]
+        let test_data = [
+            (RGB16 {      r:   0, g:     0, b:    0},            0,   // input
+            Apa102Pixel { red: 0, green: 0, blue: 0, brightness: 0}), // output
+
+            // 0 brightness brings all colors down to 0
+            (RGB16 {      r:   0xffff, g:     0xffff, b:    0xffff},            0,
+            Apa102Pixel { red: 0,      green: 0,      blue: 0,      brightness: 0}),
+
+            // color values below 8 become 0 at max brightness
+            (RGB16 {      r:   8, g:     7, b:    0},            255,
+            Apa102Pixel { red: 1, green: 0, blue: 0, brightness: 1}),
+
+            (RGB16 {      r:   0xffff, g:     0x00f0, b:    0x000f},            0x01,
+            Apa102Pixel { red: 0x11,   green: 0x00,   blue: 0x00,   brightness: 0x01}),
+
+            (RGB16 {      r:   0x0100, g:     0x00f0, b:    0x000f},            0xff,
+            Apa102Pixel { red: 0x08,   green: 0x08,   blue: 0x00,   brightness: 0x03}),
+
+            (RGB16 {      r:   0x2000, g:     0x1000, b:    0x0f00},            0x20,
+            Apa102Pixel { red: 0x20,   green: 0x10,   blue: 0x0f,   brightness: 0x03}),
+
+            (RGB16 {      r:   0xffff, g:     0x8000, b:    0x4000},            0x40,
+            Apa102Pixel { red: 0x81,   green: 0x41,   blue: 0x20,   brightness: 0x0f}),
+
+            (RGB16 {      r:   0xffff, g:     0x8000, b:    0x4000},            0x80,
+            Apa102Pixel { red: 0x81,   green: 0x41,   blue: 0x20,   brightness: 0x1f}),
+
+            (RGB16 {      r:   0xffff, g:     0xffff, b:    0xffff},            0xff,
+            Apa102Pixel { red: 0xff,   green: 0xff,   blue: 0xff,   brightness: 0x1f}),
+        ];
+
+        for data in test_data {
+            let rgb16 = data.0;
+            let result = five_bit_bitshift(rgb16, data.1);
+            assert_eq!(result, data.2, "input: {}, brightness: {}", data.0, data.1);
+        }
+    }
+
+    #[test]
+    fn test_five_bit_hd_gamma_bitshift() {
+        #[rustfmt::skip]
+        let test_data = [
+            (RGB8 {       r:   0, g:     0, b:    0},            0,   // input
+            Apa102Pixel { red: 0, green: 0, blue: 0, brightness: 0}), // output
+            // 0 brightness brings all colors down to 0
+            (RGB8 {       r:   255, g:     255, b:    255},          0,
+            Apa102Pixel { red: 0,   green: 0,   blue: 0, brightness: 0}),
+
+            (RGB8 {       r:   16, g:     16, b:    16},           16,
+            Apa102Pixel { red: 0,  green: 0,  blue: 0, brightness: 1}),
+
+            (RGB8 {       r:   64, g:     64, b:    64},           8,
+            Apa102Pixel { red: 4,  green: 4,  blue: 4, brightness: 1}),
+
+            (RGB8 {       r:   255, g:     127, b:    43},           1,
+            Apa102Pixel { red: 17,  green: 3,   blue: 0, brightness: 1}),
+
+            (RGB8 {       r:   255, g:     127, b:    43},           64,
+            Apa102Pixel { red: 129, green: 21,  blue: 1, brightness: 15}),
+
+            (RGB8 {       r:   255, g:     127, b:    43},           255,
+            Apa102Pixel { red: 255, green: 42,  blue: 3, brightness: 31}),
+
+            (RGB8 {       r:   255, g:     255, b:    255},            255,
+            Apa102Pixel { red: 255, green: 255, blue: 255, brightness: 31}),
+        ];
+
+        for data in test_data {
+            let result = five_bit_hd_gamma_bitshift(&data.0, data.1, None);
+            assert_eq!(result, data.2, "input {}, brightness {}", data.0, data.1);
+        }
+    }
+}


### PR DESCRIPTION
`impl From<RGB8>` is implemented for this new struct and the trait bound for `SmartLedsWrite::write` was already specified as `Into<Self::Color>`, so this is not a breaking change for downstreams passing iterators of RGB8 into `SmartLedsWrite::write`.

Implemented on top of #14 so this change applies to both sync and async implementations.