### PR TITLE
simplify end frame handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,19 +34,19 @@
 //! #   }
 //! # }
 //! # let get_spi_peripheral_from_your_hal = DummySpi {};
-//! use apa102_spi::{Apa102, Apa102Pixel, u5, SmartLedsWrite, RGB8};
+//! use apa102_spi::{u5, Apa102, Apa102Pixel, PixelOrder, SmartLedsWrite, RGB8};
 //!
 //! // You only need to specify MOSI and clock pins for your SPI peripheral.
 //! // APA102 LEDs do not send data over MISO and do not have a CS pin.
 //! let spi = get_spi_peripheral_from_your_hal;
-//! let mut led_strip = Apa102::new(spi);
+//! let mut led_strip = Apa102::new(spi, 1, PixelOrder::BGR);
 //!
 //! // Specify pixel values as 8 bit RGB + 5 bit brightness
 //! let led_buffer = [Apa102Pixel { red: 255, green: 0, blue: 0, brightness: u5::new(1) }];
 //! led_strip.write(led_buffer);
 //!
 //! // Specify pixel values with 8 bit RGB values
-//! let led_buffer_rgb = [RGB8 { r: 255, g: 0, b: 0}];
+//! let led_buffer_rgb = [RGB8 { r: 255, g: 0, b: 0 }];
 //! // Brightness is set to maximum value (31) in `impl From<RGB8> for Apa102Pixel`
 //! led_strip.write(led_buffer_rgb);
 //!

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,7 +6,6 @@ use super::{bisync, SmartLedsWrite, SpiBus};
 #[bisync]
 pub struct Apa102<SPI> {
     spi: SPI,
-    invert_end_frame: bool,
     pixel_order: PixelOrder,
 }
 
@@ -20,19 +19,16 @@ where
     pub fn new(spi: SPI) -> Self {
         Self {
             spi,
-            invert_end_frame: true,
             pixel_order: PixelOrder::BGR,
         }
     }
 
     pub fn new_with_options(
         spi: SPI,
-        invert_end_frame: bool,
         pixel_order: PixelOrder,
     ) -> Self {
         Self {
             spi,
-            invert_end_frame,
             pixel_order,
         }
     }
@@ -130,10 +126,7 @@ where
         // https://cpldcpu.com/2016/12/13/sk9822-a-clone-of-the-apa102/
         self.spi.write(&[0x00, 0x00, 0x00, 0x00]).await?;
         for _ in 0..num_end_frames {
-            match self.invert_end_frame {
-                false => self.spi.write(&[0xFF]).await?,
-                true => self.spi.write(&[0x00]).await?,
-            };
+            self.spi.write(&[0x00]).await?;
         }
         Ok(())
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -126,6 +126,9 @@ where
                 }
             }
         }
+        // Need an extra start frame for SK9822 to update immediately. Has no effect for APA102
+        // https://cpldcpu.com/2016/12/13/sk9822-a-clone-of-the-apa102/
+        self.spi.write(&[0x00, 0x00, 0x00, 0x00]).await?;
         for _ in 0..num_end_frames {
             match self.invert_end_frame {
                 false => self.spi.write(&[0xFF]).await?,


### PR DESCRIPTION
In #3, the end_frame_length and invert_end_frame options were added (without any documentation of what these are for or how users should use them). Neither are necessary.

The end_frame_length can be calculated from the number of LEDs, which is available by specifying the trait bound ExactSizeIterator for the IntoIterator trait's IntoIter associated type. That requires a change in smart-leds-trait. 

invert_end_frame is pointless. If the end frame is all 1s, any LEDs past the end of those addressed light up full brightness white, whereas nothing bad happens in any case if the end frame is all 0s.