### PR TITLE
pub use smart_leds_trait symbols

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! There are several ways to send pixel data:
 //!   * Handle all details of the protocol yourself with the [Apa102Pixel] struct, 8 bit RGB + 5 bits brightness
-//!   * Simply provide [smart_leds_trait::RGB8] values, hardcoding maximum brightness. This may be uncomfortably bright.
-//!   * Use [FastLED's pseudo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/master/APA102.md) to convert [smart_leds_trait::RGB8] + 8 bit brightness to 8 bit RGB + 5 bit brightness.
+//!   * Simply provide [RGB8] values, hardcoding maximum brightness. This may be uncomfortably bright.
+//!   * Use [FastLED's pseudo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/master/APA102.md) to convert [RGB8] + 8 bit brightness to 8 bit RGB + 5 bit brightness.
 //!
 //! ```
 //! # use embedded_hal::spi::{SpiBus, ErrorType, ErrorKind};
@@ -34,8 +34,7 @@
 //! #   }
 //! # }
 //! # let get_spi_peripheral_from_your_hal = DummySpi {};
-//! use smart_leds_trait::{SmartLedsWrite, RGB8};
-//! use apa102_spi::{Apa102, Apa102Pixel, u5};
+//! use apa102_spi::{Apa102, Apa102Pixel, u5, SmartLedsWrite, RGB8};
 //!
 //! // You only need to specify MOSI and clock pins for your SPI peripheral.
 //! // APA102 LEDs do not send data over MISO and do not have a CS pin.
@@ -61,6 +60,8 @@
 //!   * `defmt`: impl [defmt::Format] for [Apa102Pixel] (off by default)
 
 #![no_std]
+
+pub use smart_leds_trait::{SmartLedsWrite, SmartLedsWriteAsync, RGB, RGB16, RGB8};
 
 mod pixel;
 pub use pixel::Apa102Pixel;

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -37,8 +37,8 @@ impl From<RGB8> for Apa102Pixel {
 }
 
 impl Apa102Pixel {
-    /// Convert an [rgb::RGB8](https://docs.rs/rgb/latest/rgb/type.RGB8.html) to an [Apa102Pixel]
-    /// with a specified brightness level. Any [u8] is a valid brightness level from 0 to 255.
+    /// Convert an [RGB8] to an [Apa102Pixel] with a specified brightness level.
+    /// Any [u8] is a valid brightness level from 0 to 255.
     /// [FastLED's psuedo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/d5aaf65be19782f3e52b8b0fe38778f14376a293/APA102.md)
     /// is used to make use of the dynamic range available from the APA102 protocol, preserving
     /// color detail at low brightness. In short, it converts:
@@ -54,14 +54,13 @@ impl Apa102Pixel {
         crate::pseudo13::five_bit_hd_gamma_bitshift(&rgb8, brightness, color_correction)
     }
 
-    /// Convert an [rgb::RGB16](https://docs.rs/rgb/latest/rgb/type.RGB16.html) to an [Apa102Pixel]
-    /// with a specified brightness level. Any [u8] is a valid brightness level from 0 to 255.
+    /// Convert an [RGB16] to an [Apa102Pixel] with a specified brightness level.
+    /// Any [u8] is a valid brightness level from 0 to 255.
     /// [FastLED's psuedo-13-bit gamma correction algorithm](https://github.com/FastLED/FastLED/blob/d5aaf65be19782f3e52b8b0fe38778f14376a293/APA102.md)
     /// is used to make use of the dynamic range available from the APA102 protocol, preserving
     /// color detail at low brightness.
     ///
-    /// This function does not apply gamma correction; the [rgb::RGB16](https://docs.rs/rgb/latest/rgb/type.RGB16.html)
-    /// input is assumed to be gamma corrected already.
+    /// This function does not apply gamma correction; the [RGB16] input is assumed to be gamma corrected already.
     pub fn from_rgb16_with_brightness(rgb16: RGB16, brightness: u8) -> Self {
         crate::pseudo13::five_bit_bitshift(rgb16, brightness)
     }


### PR DESCRIPTION
Before, downstream users had to add smart-leds-trait to their Cargo.toml and keep the version in sync with that required by this crate. Now, all necessary symbols are re-exported.

Implemented on top of #17 to avoid merge conflicts.