### PR TITLE
rename Apa102[Async] struct to Apa102Writer[Async]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,12 @@
 //! #   }
 //! # }
 //! # let get_spi_peripheral_from_your_hal = DummySpi {};
-//! use apa102_spi::{u5, Apa102, Apa102Pixel, PixelOrder, SmartLedsWrite, RGB8};
+//! use apa102_spi::{u5, Apa102Pixel, Apa102Writer, PixelOrder, SmartLedsWrite, RGB8};
 //!
 //! // You only need to specify MOSI and clock pins for your SPI peripheral.
 //! // APA102 LEDs do not send data over MISO and do not have a CS pin.
 //! let spi = get_spi_peripheral_from_your_hal;
-//! let mut led_strip = Apa102::new(spi, 1, PixelOrder::default());
+//! let mut led_strip = Apa102Writer::new(spi, 1, PixelOrder::default());
 //!
 //! // Specify pixel values as 8 bit RGB + 5 bit brightness
 //! let led_buffer = [Apa102Pixel { red: 255, green: 0, blue: 0, brightness: u5::new(1) }];
@@ -107,7 +107,7 @@ mod asynchronous {
     mod writer;
     pub use writer::*;
 }
-pub use asynchronous::Apa102 as Apa102Async;
+pub use asynchronous::Apa102Writer as Apa102WriterAsync;
 
 #[path = "."]
 mod blocking {
@@ -118,4 +118,4 @@ mod blocking {
     mod writer;
     pub use writer::*;
 }
-pub use blocking::Apa102;
+pub use blocking::Apa102Writer;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,14 +4,14 @@ use super::{bisync, SmartLedsWrite, SpiBus};
 
 /// A writer for APA102 LEDs
 #[bisync]
-pub struct Apa102<SPI> {
+pub struct Apa102Writer<SPI> {
     spi: SPI,
     end_frame_length_bytes: usize,
     pixel_order: PixelOrder,
 }
 
 #[bisync]
-impl<SPI> Apa102<SPI>
+impl<SPI> Apa102Writer<SPI>
 where
     SPI: SpiBus,
 {
@@ -35,7 +35,7 @@ where
 }
 
 #[bisync]
-impl<SPI> SmartLedsWrite for Apa102<SPI>
+impl<SPI> SmartLedsWrite for Apa102Writer<SPI>
 where
     SPI: SpiBus,
 {


### PR DESCRIPTION
This clarifies its relationship to the APA102 LEDs. Now that there is another struct called `Apa102Pixel`, it could get confusing what exactly something called merely `Apa102` is.

I don't have a very strong opinion about this change; if you decide it's not worth the braking change, that's fine. I think the trouble of adjusting to the breaking change is trivial though, and there are already a few breaking changes in the master branch.