### PR TITLE
bump defmt to 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smart-leds-trait = "0.3.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 ux = "0.1"
-defmt = { version = "0.3.0", optional = true }
+defmt = { version = "1.0.1", optional = true }
 
 [features]
 defmt = [ "dep:defmt" ]


### PR DESCRIPTION
`cargo test` passes